### PR TITLE
Added `dependencies::convert`

### DIFF
--- a/assets/dependencies/syntax.txt
+++ b/assets/dependencies/syntax.txt
@@ -1,7 +1,7 @@
 0 "," [w? "," w?]
 1 "dependency" [t!"name" w? ":" w? "{" w? "\"version\"" w? ":" w? t!"version" w? "}"]
-1 "library" [t!"name" w? ":" w? "{" w? s?(@","){{
+1 "package" [t!"name" w? ":" w? "{" w? s?(@","){{
     ["\"version\"" w? ":" w? t!"version"]
     ["\"dependencies\"" w? ":" w? "{" w? s?(@","){@"dependency""dependency"} w? "}"]
 }} w? "}"]
-2 "document" [w? "{" w? s?(@","){[@"library""library" w?]} "}" w?]
+2 "document" [w? "{" w? s?(@","){[@"package""package" w?]} "}" w?]

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -52,6 +52,28 @@ pub fn write<W: Write>(package_data: &[Package], w: &mut W) {
     writeln!(w, "}}").unwrap();
 }
 
+/// Converts from meta data to dependency information.
+pub fn convert(
+    mut data: &[(Range, MetaData)],
+    ignored: &mut Vec<Range>
+) -> Result<Vec<Package>, ()> {
+    use piston_meta::bootstrap::update;
+
+    let mut offset = 0;
+    let mut res = vec![];
+    loop {
+        if let Ok((range, package)) = Package::from_meta_data(data, offset, ignored) {
+            update(range, &mut data, &mut offset);
+            res.push(package);
+        } else if offset < data.len() {
+            return Err(());
+        } else {
+            break;
+        }
+    }
+    Ok(res)
+}
+
 /// Stores package information.
 pub struct Package {
     /// The package name.

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ mod tests {
             "assets/dependencies/test.txt");
         let _data = load_syntax_data("assets/dependencies/syntax.txt",
             "assets/dependencies/test2.txt");
-        // json::print(&_data);
+        json::print(&_data);
     }
 
     #[test]


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/eco/issues/30
- Change node “library” to “package” to reuse converting from
  Cargo.toml data
