### PR TITLE
Ignore "todo.txt"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ watch.sh
 examples/hgl_triangle
 
 Cargo.lock
+
+todo.txt


### PR DESCRIPTION
Makes it possible to do `cargo run > todo.txt` when working on updating
libraries.
