### PR TITLE
Ignore Glutin 0.3.0 in Piston's ecosystem

### DIFF
--- a/assets/extract/piston.txt
+++ b/assets/extract/piston.txt
@@ -196,7 +196,8 @@
     },
 
     "glutin": {
-        "url": "https://raw.githubusercontent.com/tomaka/glutin/master/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/tomaka/glutin/master/Cargo.toml",
+        "ignore-version": "0.3.0"
     },
 
     "glfw": {


### PR DESCRIPTION
Glium won’t update for some time.
