### PR TITLE
Added "imageproc" to Piston's ecosystem

### DIFF
--- a/assets/extract/piston.txt
+++ b/assets/extract/piston.txt
@@ -179,6 +179,10 @@
         "url": "https://raw.githubusercontent.com/PistonDevelopers/image/master/Cargo.toml"
     },
 
+    "imageproc": {
+        "url": "https://raw.githubusercontent.com/PistonDevelopers/imageproc/master/Cargo.toml"
+    },
+
     "gif": {
         "url": "https://raw.githubusercontent.com/PistonDevelopers/image-gif/master/Cargo.toml"
     },
@@ -320,7 +324,8 @@
     },
 
     "draw_state": {
-        "url": "https://raw.githubusercontent.com/gfx-rs/draw_state/master/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/gfx-rs/draw_state/master/Cargo.toml",
+        "ignore-version": "0.2.0"
     },
 
     "glium": {


### PR DESCRIPTION
- Ignore 0.2.0 updates of draw_state temporarily
