### PR TITLE
Remove "elmesque" from Piston's ecosystem

### DIFF
--- a/assets/extract/piston.txt
+++ b/assets/extract/piston.txt
@@ -170,11 +170,7 @@
     "conrod": {
         "url": "https://raw.githubusercontent.com/PistonDevelopers/conrod/master/Cargo.toml"
     },
-
-    "elmesque": {
-        "url": "https://raw.githubusercontent.com/mitchmindtree/elmesque/master/Cargo.toml"
-    },
-
+    
     "image": {
         "url": "https://raw.githubusercontent.com/PistonDevelopers/image/master/Cargo.toml"
     },


### PR DESCRIPTION
This is library is no longer in use by Conrod.
