### PR TITLE
Minor fixes, minimize work in Piston ecosystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eco"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>"
 ]

--- a/assets/extract/piston.txt
+++ b/assets/extract/piston.txt
@@ -91,7 +91,7 @@
         "url": "https://raw.githubusercontent.com/PistonDevelopers/vecmath/master/Cargo.toml"
     },
 
-    "piston2d-cam": {
+    "piston3d-cam": {
         "url": "https://raw.githubusercontent.com/PistonDevelopers/cam/master/Cargo.toml"
     },
 
@@ -127,7 +127,7 @@
         "url": "https://raw.githubusercontent.com/PistonDevelopers/camera_controllers/master/Cargo.toml"
     },
 
-    "drag_controller": {
+    "piston2d-drag_controller": {
         "url": "https://raw.githubusercontent.com/PistonDevelopers/drag_controller/master/Cargo.toml"
     },
 
@@ -180,8 +180,7 @@
     },
 
     "gif": {
-        "url": "https://raw.githubusercontent.com/PistonDevelopers/image-gif/master/Cargo.toml",
-        "ignore-version": "0.7.0"
+        "url": "https://raw.githubusercontent.com/PistonDevelopers/image-gif/master/Cargo.toml"
     },
 
     "png": {
@@ -201,7 +200,8 @@
     },
 
     "freetype-rs": {
-        "url": "https://raw.githubusercontent.com/PistonDevelopers/freetype-rs/master/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/PistonDevelopers/freetype-rs/master/Cargo.toml",
+        "ignore-version": "0.7.0"
     },
 
     "freetype-sys": {
@@ -217,7 +217,8 @@
     },
 
     "sdl2": {
-        "url": "https://raw.githubusercontent.com/AngryLawyer/rust-sdl2/master/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/AngryLawyer/rust-sdl2/master/Cargo.toml",
+        "ignore-version": "0.18.0"
     },
 
     "sdl2-sys": {
@@ -228,7 +229,7 @@
         "url": "https://raw.githubusercontent.com/PistonDevelopers/gfx_texture/master/Cargo.toml"
     },
 
-    "piston-gfx_voxel": {
+    "piston3d-gfx_voxel": {
         "url": "https://raw.githubusercontent.com/PistonDevelopers/gfx_voxel/master/Cargo.toml"
     },
 
@@ -236,19 +237,20 @@
         "url": "https://raw.githubusercontent.com/PistonDevelopers/hematite/master/Cargo.toml"
     },
 
-    "hematite_nbt": {
+    "hematite-nbt": {
         "url": "https://raw.githubusercontent.com/PistonDevelopers/hematite_nbt/master/Cargo.toml"
     },
 
     "hematite_server": {
-        "url": "https://raw.githubusercontent.com/PistonDevelopers/hematite_server/master/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/PistonDevelopers/hematite_server/master/Cargo.toml",
+        "ignore-version": "0.0.1"
     },
 
     "fps_counter": {
         "url": "https://raw.githubusercontent.com/PistonDevelopers/fps_counter/master/Cargo.toml"
     },
 
-    "opengex": {
+    "piston-opengex": {
         "url": "https://raw.githubusercontent.com/PistonDevelopers/opengex/master/Cargo.toml"
     },
 
@@ -284,7 +286,7 @@
         "url": "https://raw.githubusercontent.com/PistonDevelopers/current/master/Cargo.toml"
     },
 
-    "music": {
+    "piston-music": {
         "url": "https://raw.githubusercontent.com/PistonDevelopers/music/master/Cargo.toml"
     },
 
@@ -300,19 +302,27 @@
         "url": "https://raw.githubusercontent.com/PistonDevelopers/mush/master/Cargo.toml"
     },
 
+    "gfx_core": {
+        "url": "https://raw.githubusercontent.com/gfx-rs/gfx/master/src/core/Cargo.toml",
+        "ignore-version": "0.3.0"
+    },
+
     "gfx": {
-        "url": "https://raw.githubusercontent.com/gfx-rs/gfx/master/src/core/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/gfx-rs/gfx/master/src/render/Cargo.toml",
+        "ignore-version": "0.11.0"
     },
 
     "gfx_device_gl": {
-        "url": "https://raw.githubusercontent.com/gfx-rs/gfx/master/src/backend/gl/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/gfx-rs/gfx/master/src/backend/gl/Cargo.toml",
+        "ignore-version": "0.10.0"
     },
 
     "glium": {
-        "url": "https://raw.githubusercontent.com/tomaka/glium/master/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/tomaka/glium/master/Cargo.toml",
+        "ignore-version": "0.14.0"
     },
 
-    "gl-rs": {
+    "gl": {
         "url": "https://raw.githubusercontent.com/bjz/gl-rs/master/gl/Cargo.toml"
     },
 
@@ -369,7 +379,8 @@
     },
 
     "sdl2_mixer": {
-        "url": "https://raw.githubusercontent.com/andelf/rust-sdl2_mixer/master/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/andelf/rust-sdl2_mixer/master/Cargo.toml",
+        "ignore-version": "0.17.0"
     },
 
     "gl": {

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -47,18 +47,15 @@
 //! ```
 //!
 //! A new version of library B is available, but some work might be needed in A
-//! before releasing a new version. By listing "0.7.0" in the ignore-version
+//! before releasing a new version. By listing "0.8.0" in the ignore-version
 //! field, there will be no recommended update for A. This will also avoid
 //! further updates for libraries depending on A triggered by this version.
 //!
-//! However, if A breaks for other reasons, there will be update actions for
-//! libraries higher up in the dependency graph.
+//! This might cause unsoundness (see top level documentation) when done to
+//! a library that is not at the bottom of the dependency graph.
 //!
-//! The rule used for ignoring version is: If the package has not this version,
+//! The rule used for ignoring version is: If the package has this version,
 //! then filter it from dependency info.
-//!
-//! This might cause unsoundness (see top level documentation).
-//! Remember to remove ignore-version fields that are no longer needed.
 //!
 //! ### Override version
 //!
@@ -237,8 +234,12 @@ pub fn extract_dependency_info_from(extract_info: &str) -> Result<String, String
             let mut package = try!(convert_cargo_toml(
                 &cargo_toml_data, &mut ignored)
                 .map_err(|_| format!("Could not convert Cargo.toml data for url `{}`", &extract.url)));
+            if extract.package != package.name {
+                return Err(format!("Wrong Cargo.toml: `{}` does not match `{}`",
+                                   extract.package, package.name));
+            }
             if let Some(ref ignore_version) = extract.ignore_version {
-                if ignore_version != &package.version { return Ok(()); }
+                if ignore_version == &package.version { return Ok(()); }
             }
             if let Some(ref override_version) = extract.override_version {
                 package.version = override_version.clone();


### PR DESCRIPTION
- Bumped to 0.14.0
- Fixed ignore rule
- Added error when package name is wrong
- Ignore Gfx 0.11.0 temporarily in Piston’s ecosystem (wait for next
  version to reduce amount of work)
- Ignore updates to sdl2 temporarily
  [PR](https://github.com/AngryLawyer/rust-sdl2/pull/508)
- Ignore updates to hematite_server
  [PR](https://github.com/PistonDevelopers/hematite_server/pull/115)
- Ignore updates to sdl2_mixer temporarily (wait for next sdl2 version)
- Ignore updates to freetype-rs temporarily (not necessary now)
- Remove ignore field on gif (image has been updated)
