### PR TITLE
Added precise control over ignored dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eco"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>"
 ]

--- a/assets/dependencies/syntax.txt
+++ b/assets/dependencies/syntax.txt
@@ -1,5 +1,8 @@
 0 , = [.w? "," .w?]
-1 dependency = [.t!:"name" .w? ":" .w? "{" .w? "\"version\"" .w? ":" .w? .t!:"version" .w? "}"]
+1 dependency = [.t!:"name" .w? ":" .w? "{" .w? .s?(, {
+    ["\"version\"" .w? ":" .w? .t!:"version"]
+    ["\"ignore-version\"" .w? ":" .w? .t!:"ignore-version"]
+}) .w? "}"]
 1 package = [.t!:"name" .w? ":" .w? "{" .w? .s?(, {
     ["\"version\"" .w? ":" .w? .t!:"version"]
     ["\"dependencies\"" .w? ":" .w? "{" .w? .s?(, dependency:"dependency") .w? "}"]

--- a/assets/dependencies/test4.txt
+++ b/assets/dependencies/test4.txt
@@ -1,0 +1,11 @@
+{
+    "pistoncore-input": {
+        "version": "0.4.0",
+        "dependencies": {
+            "bitflags": {
+                "version": "0.6.0",
+                "ignore-version": "0.7.0"
+            }
+        }
+    }
+}

--- a/assets/extract/piston.txt
+++ b/assets/extract/piston.txt
@@ -60,11 +60,17 @@
     },
 
     "piston2d-opengl_graphics": {
-        "url": "https://raw.githubusercontent.com/PistonDevelopers/opengl_graphics/master/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/PistonDevelopers/opengl_graphics/master/Cargo.toml",
+        "ignore": {
+            "piston-shaders_graphics2d": "0.2.1"
+        }
     },
 
     "piston2d-glium_graphics": {
-        "url": "https://raw.githubusercontent.com/PistonDevelopers/glium_graphics/master/Cargo.toml"
+        "url": "https://raw.githubusercontent.com/PistonDevelopers/glium_graphics/master/Cargo.toml",
+        "ignore": {
+          "piston-shaders_graphics2d": "0.2.1"
+        }
     },
 
     "piston-ai_behavior": {

--- a/assets/extract/syntax.txt
+++ b/assets/extract/syntax.txt
@@ -1,6 +1,10 @@
+3 ignore_dependency = [.t!:"package" .w? ":" .w? .t!:"version"]
+2 ignore = ["{" .w? .s?([.w? "," .w?]
+    ignore_dependency:"dependency") .w? "}"]
 1 library = [.t!:"package" .w? ":" .w? "{" .w? .s?([.w? "," .w?] {
     ["\"url\"" .w? ":" .w? .t!:"url"]
     ["\"ignore-version\"" .w? ":" .w? .t!:"ignore_version"]
     ["\"override-version\"" .w? ":" .w? .t!:"override_version"]
+    ["\"ignore\"" .w? ":" .w? ignore:"ignore"]
 }) .w? "}"]
 0 document = [.w? "{" .w? .s?([.w? "," .w?] [library:"library" .w?]) "}" .w?]

--- a/assets/extract/test3.txt
+++ b/assets/extract/test3.txt
@@ -1,0 +1,8 @@
+{
+    "piston2d-opengl_graphics": {
+        "url": "https://raw.githubusercontent.com/PistonDevelopers/opengl_graphics/master/Cargo.toml",
+        "ignore": {
+            "piston-shaders_graphics2d": "0.2.1"
+        }
+    },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,10 @@ mod tests {
     fn extract() {
         let _data = load_syntax_data("assets/extract/syntax.txt",
             "assets/extract/test.txt");
+        let _data = load_syntax_data("assets/extract/syntax.txt",
+            "assets/extract/test2.txt");
+            let _data = load_syntax_data("assets/extract/syntax.txt",
+                "assets/extract/test3.txt");
         // json::print(&_data);
     }
 
@@ -107,6 +111,8 @@ mod tests {
             "assets/dependencies/test2.txt");
         let _data = load_syntax_data("assets/dependencies/syntax.txt",
             "assets/dependencies/test3.txt");
+        let _data = load_syntax_data("assets/dependencies/syntax.txt",
+            "assets/dependencies/test4.txt");
         // json::print(&_data);
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -304,6 +304,10 @@ pub fn generate_update_info_from(dependency_info: &str) -> Result<String, String
                     &dep.version, &dep.name, &package.name)));
             let new_version = new_versions.get(&dep.name).unwrap();
             if breaks(new_version, &old_version) {
+                if let Some(ref ignore_version) = dep.ignore_version {
+                    // Ignore update to a specific version.
+                    if &new_version.to_string() == &**ignore_version { continue; }
+                }
                 update_dependencies.push(Dependency {
                         name: dep.name.clone(),
                         bump: Bump {
@@ -353,6 +357,10 @@ pub fn generate_update_info_from(dependency_info: &str) -> Result<String, String
                     &dep.version, &dep.name, &package.name)));
             let new_version = new_versions.get(&dep.name).unwrap();
             if breaks(new_version, &old_version) {
+                if let Some(ref ignore_version) = dep.ignore_version {
+                    // Ignore update to a specific version.
+                    if &new_version.to_string() == &**ignore_version { continue; }
+                }
                 update_package.dev_dependencies.push(Dependency {
                         name: dep.name.clone(),
                         bump: Bump {


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/eco/issues/134
- Bumped to 0.15.0
- Updated dependency info syntax
- Added test for dependency info
- Ignore shaders_graphics2d 0.2.1 in opengl_graphics and glum_graphics
- Updated extract info syntax
- Added test for extract info
- Updated writing of dependency info
- Updated meta data converting for dependency info
- Updated meta data converting for extract info
- Copy ignored version from extract info to extracted dependency info
  from Cargo.tom
- Ignore updates of ignored versions
- Added ignore field to extract info docs
