### PR TITLE
Rustfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib
 export DEP_OPENSSL_INCLUDE=`brew --prefix openssl`/include
 ```
 
+## Making pull requests
+
+Prior to making a pull request on eco, make sure that you have `cargo fmt` against the
+codebase. Instructions to install `rustfmt` can be found [here](https://github.com/rust-lang-nursery/rustfmt).
+Ensure that you are installing the nightly version, since there is currently an effort
+to port `rustfmt` away from the `syntex` crate, and `rustfmt-nightly` is the latest version.
+
+Unfortunately, this also means that you will have to switch over to nightly prior to
+running `cargo fmt` against the codebase.
+
 ## License
 
 Licensed under either of

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -1,17 +1,14 @@
 //! Dependency info.
 
 use range::Range;
-use piston_meta::{ json, MetaData };
+use piston_meta::{json, MetaData};
 use piston_meta::bootstrap::Convert;
 
 use std::sync::Arc;
-use std::io::{ self, Write };
+use std::io::{self, Write};
 
 /// Writes the dependency info.
-pub fn write<W: Write>(
-    package_data: &[Package],
-    w: &mut W
-) -> Result<(), io::Error> {
+pub fn write<W: Write>(package_data: &[Package], w: &mut W) -> Result<(), io::Error> {
     let write_dep = |w: &mut W, dependency: &Dependency, has_next: bool| -> Result<(), io::Error> {
         try!(write!(w, "   "));
         try!(json::write_string(w, &dependency.name));
@@ -76,10 +73,7 @@ pub fn write<W: Write>(
 }
 
 /// Converts from meta data to dependency information.
-pub fn convert(
-    data: &[Range<MetaData>],
-    ignored: &mut Vec<Range>
-) -> Result<Vec<Package>, ()> {
+pub fn convert(data: &[Range<MetaData>], ignored: &mut Vec<Range>) -> Result<Vec<Package>, ()> {
     let mut convert = Convert::new(data);
     let mut res = vec![];
     loop {
@@ -111,7 +105,7 @@ impl Package {
     /// Converts from meta data.
     pub fn from_meta_data(
         mut convert: Convert,
-        ignored: &mut Vec<Range>
+        ignored: &mut Vec<Range>,
     ) -> Result<(Range, Package), ()> {
         let start = convert.clone();
         let node = "package";
@@ -132,14 +126,14 @@ impl Package {
             } else if let Ok((range, val)) = convert.meta_string("version") {
                 convert.update(range);
                 version = Some(val);
-            } else if let Ok((range, dependency)) = Dependency::from_meta_data(
-                "dependency", convert, ignored
-            ) {
+            } else if let Ok((range, dependency)) =
+                Dependency::from_meta_data("dependency", convert, ignored)
+            {
                 convert.update(range);
                 dependencies.push(dependency);
-            } else if let Ok((range, dev_dependency)) = Dependency::from_meta_data(
-                "dev_dependency", convert, ignored
-            ) {
+            } else if let Ok((range, dev_dependency)) =
+                Dependency::from_meta_data("dev_dependency", convert, ignored)
+            {
                 convert.update(range);
                 dev_dependencies.push(dev_dependency);
             } else {
@@ -151,12 +145,15 @@ impl Package {
 
         let name = try!(name.ok_or(()));
         let version = try!(version.ok_or(()));
-        Ok((convert.subtract(start), Package {
-            name: name,
-            version: version,
-            dependencies: dependencies,
-            dev_dependencies: dev_dependencies,
-        }))
+        Ok((
+            convert.subtract(start),
+            Package {
+                name: name,
+                version: version,
+                dependencies: dependencies,
+                dev_dependencies: dev_dependencies,
+            },
+        ))
     }
 }
 
@@ -175,7 +172,7 @@ impl Dependency {
     pub fn from_meta_data(
         node: &str,
         mut convert: Convert,
-        ignored: &mut Vec<Range>
+        ignored: &mut Vec<Range>,
     ) -> Result<(Range, Dependency), ()> {
         let start = convert.clone();
         let start_range = try!(convert.start_node(node));
@@ -206,10 +203,13 @@ impl Dependency {
 
         let name = try!(name.ok_or(()));
         let version = try!(version.ok_or(()));
-        Ok((convert.subtract(start), Dependency {
-            name: name,
-            version: version,
-            ignore_version: ignore_version
-        }))
+        Ok((
+            convert.subtract(start),
+            Dependency {
+                name: name,
+                version: version,
+                ignore_version: ignore_version,
+            },
+        ))
     }
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -93,7 +93,7 @@
 
 use piston_meta::MetaData;
 use piston_meta::bootstrap::Convert;
-use dependencies::{ self, Package };
+use dependencies::{self, Package};
 use range::Range;
 use std::sync::Arc;
 
@@ -115,7 +115,7 @@ impl Extract {
     /// Converts from meta data.
     pub fn from_meta_data(
         mut convert: Convert,
-        ignored: &mut Vec<Range>
+        ignored: &mut Vec<Range>,
     ) -> Result<(Range, Extract), ()> {
         let start = convert.clone();
         let node = "library";
@@ -155,19 +155,22 @@ impl Extract {
 
         let package = try!(package.ok_or(()));
         let url = try!(url.ok_or(()));
-        Ok((convert.subtract(start), Extract {
-            package: package,
-            url: url,
-            ignore_version: ignore_version,
-            override_version: override_version,
-            ignore: ignore,
-        }))
+        Ok((
+            convert.subtract(start),
+            Extract {
+                package: package,
+                url: url,
+                ignore_version: ignore_version,
+                override_version: override_version,
+                ignore: ignore,
+            },
+        ))
     }
 }
 
 fn ignore_from_meta_data(
     mut convert: Convert,
-    ignored: &mut Vec<Range>
+    ignored: &mut Vec<Range>,
 ) -> Result<(Range, Vec<(Arc<String>, Arc<String>)>), ()> {
     let start = convert.clone();
     let node = "ignore";
@@ -194,7 +197,7 @@ fn ignore_from_meta_data(
 
 fn dependency_from_meta_data(
     mut convert: Convert,
-    ignored: &mut Vec<Range>
+    ignored: &mut Vec<Range>,
 ) -> Result<(Range, (Arc<String>, Arc<String>)), ()> {
     let start = convert.clone();
     let node = "dependency";
@@ -228,33 +231,38 @@ fn dependency_from_meta_data(
 /// Loads a text file from url.
 pub fn load_text_file_from_url(url: &str) -> Result<String, String> {
     use hyper::client::Client;
-    use hyper::{Url};
+    use hyper::Url;
     use hyper::status::StatusCode;
     use std::io::Read;
 
-    let url_address = try!(Url::parse(url)
-        .map_err(|e| format!("Error parsing url: {}", e)));
+    let url_address = try!(Url::parse(url).map_err(|e| format!("Error parsing url: {}", e)));
     let client = Client::new();
     let request = client.get(url_address);
-    let mut response = try!(request.send()
-        .map_err(|e| format!("Error fetching file over http {}: {}",
-            url, e.to_string())));
+    let mut response = try!(request.send().map_err(|e| format!(
+        "Error fetching file over http {}: {}",
+        url,
+        e.to_string()
+    )));
     if response.status == StatusCode::Ok {
         let mut data = String::new();
-        try!(response.read_to_string(&mut data)
-            .map_err(|e| format!("Error fetching file over http {}: {}",
-            url, e.to_string())));
+        try!(response.read_to_string(&mut data).map_err(|e| format!(
+            "Error fetching file over http {}: {}",
+            url,
+            e.to_string()
+        )));
         Ok(data)
     } else {
-        Err(format!("Error fetching file over http {}: {}",
-            url, response.status))
+        Err(format!(
+            "Error fetching file over http {}: {}",
+            url, response.status
+        ))
     }
 }
 
 /// Converts meta data into extract info.
 pub fn convert_extract_info(
     data: &[Range<MetaData>],
-    ignored: &mut Vec<Range>
+    ignored: &mut Vec<Range>,
 ) -> Result<Vec<Extract>, ()> {
     use piston_meta::bootstrap::*;
 
@@ -276,7 +284,7 @@ pub fn convert_extract_info(
 /// Converts meta data into Cargo.toml information.
 pub fn convert_cargo_toml(
     data: &[Range<MetaData>],
-    ignored: &mut Vec<Range>
+    ignored: &mut Vec<Range>,
 ) -> Result<Package, ()> {
     let (_, package) = try!(Package::from_meta_data(Convert::new(data), ignored));
     Ok((package))
@@ -289,23 +297,25 @@ pub fn extract_dependency_info_from(extract_info: &str) -> Result<String, String
     use piston_meta::*;
 
     let extract_meta_syntax = include_str!("../assets/extract/syntax.txt");
-    let extract_meta_rules = stderr_unwrap(extract_meta_syntax,
-        syntax(extract_meta_syntax));
+    let extract_meta_rules = stderr_unwrap(extract_meta_syntax, syntax(extract_meta_syntax));
     let mut extract_data = vec![];
-    stderr_unwrap(extract_info,
-        parse(&extract_meta_rules, extract_info, &mut extract_data));
+    stderr_unwrap(
+        extract_info,
+        parse(&extract_meta_rules, extract_info, &mut extract_data),
+    );
 
     let mut ignored = vec![];
-    let list = try!(convert_extract_info(&extract_data, &mut ignored)
-        .map_err(|_| String::from("Could not convert extract data")));
+    let list = try!(
+        convert_extract_info(&extract_data, &mut ignored)
+            .map_err(|_| String::from("Could not convert extract data"))
+    );
 
     // Stores package and dependency information extracted from Cargo.toml.
     let package_data = Arc::new(Mutex::new(vec![]));
 
     // Extract information.
     let cargo_toml_syntax = include_str!("../assets/cargo-toml/syntax.txt");
-    let cargo_toml_rules = Arc::new(stderr_unwrap(cargo_toml_syntax,
-        syntax(cargo_toml_syntax)));
+    let cargo_toml_rules = Arc::new(stderr_unwrap(cargo_toml_syntax, syntax(cargo_toml_syntax)));
     let mut handles = vec![];
     for extract in list.into_iter() {
         let cargo_toml_rules = cargo_toml_rules.clone();
@@ -317,22 +327,35 @@ pub fn extract_dependency_info_from(extract_info: &str) -> Result<String, String
                 Ok(val) => val,
                 Err(range_err) => {
                     let mut w: Vec<u8> = vec![];
-                    ParseErrorHandler::new(&config).write(&mut w, range_err).unwrap();
-                    return Err(format!("{}: Syntax error in Cargo.toml for url `{}`\n{}",
-                        &extract.package, &extract.url, &String::from_utf8(w).unwrap()));
+                    ParseErrorHandler::new(&config)
+                        .write(&mut w, range_err)
+                        .unwrap();
+                    return Err(format!(
+                        "{}: Syntax error in Cargo.toml for url `{}`\n{}",
+                        &extract.package,
+                        &extract.url,
+                        &String::from_utf8(w).unwrap()
+                    ));
                 }
             };
 
             let mut ignored = vec![];
-            let mut package = try!(convert_cargo_toml(
-                &cargo_toml_data, &mut ignored)
-                .map_err(|_| format!("Could not convert Cargo.toml data for url `{}`", &extract.url)));
+            let mut package = try!(convert_cargo_toml(&cargo_toml_data, &mut ignored).map_err(
+                |_| format!(
+                    "Could not convert Cargo.toml data for url `{}`",
+                    &extract.url
+                )
+            ));
             if extract.package != package.name {
-                return Err(format!("Wrong Cargo.toml: `{}` does not match `{}`",
-                                   extract.package, package.name));
+                return Err(format!(
+                    "Wrong Cargo.toml: `{}` does not match `{}`",
+                    extract.package, package.name
+                ));
             }
             if let Some(ref ignore_version) = extract.ignore_version {
-                if ignore_version == &package.version { return Ok(()); }
+                if ignore_version == &package.version {
+                    return Ok(());
+                }
             }
             if let Some(ref override_version) = extract.override_version {
                 package.version = override_version.clone();
@@ -360,8 +383,7 @@ pub fn extract_dependency_info_from(extract_info: &str) -> Result<String, String
     let mut res: Vec<u8> = vec![];
     dependencies::write(&package_data.lock().unwrap(), &mut res).unwrap();
 
-    let res = try!(String::from_utf8(res)
-        .map_err(|e| format!("UTF8 error: {}", e)));
+    let res = try!(String::from_utf8(res).map_err(|e| format!("UTF8 error: {}", e)));
 
     Ok(res)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,9 @@
 //!
 //! As long as there are no holes, the update algorithm is sound.
 
-extern crate range;
-extern crate piston_meta;
 extern crate hyper;
+extern crate piston_meta;
+extern crate range;
 extern crate semver;
 
 pub mod extract;
@@ -78,75 +78,75 @@ mod tests {
 
     #[test]
     fn extract_is_json() {
-        let _ = load_syntax_data("assets/json/syntax.txt",
-            "assets/extract/test.txt");
+        let _ = load_syntax_data("assets/json/syntax.txt", "assets/extract/test.txt");
     }
 
     #[test]
     fn extract() {
-        let _data = load_syntax_data("assets/extract/syntax.txt",
-            "assets/extract/test.txt");
-        let _data = load_syntax_data("assets/extract/syntax.txt",
-            "assets/extract/test2.txt");
-            let _data = load_syntax_data("assets/extract/syntax.txt",
-                "assets/extract/test3.txt");
+        let _data = load_syntax_data("assets/extract/syntax.txt", "assets/extract/test.txt");
+        let _data = load_syntax_data("assets/extract/syntax.txt", "assets/extract/test2.txt");
+        let _data = load_syntax_data("assets/extract/syntax.txt", "assets/extract/test3.txt");
         // json::print(&_data);
     }
 
     #[test]
     fn dependencies_is_json() {
-        let _ = load_syntax_data("assets/json/syntax.txt",
-            "assets/dependencies/test.txt");
-        let _ = load_syntax_data("assets/json/syntax.txt",
-            "assets/dependencies/test2.txt");
-        let _ = load_syntax_data("assets/json/syntax.txt",
-            "assets/dependencies/test3.txt");
+        let _ = load_syntax_data("assets/json/syntax.txt", "assets/dependencies/test.txt");
+        let _ = load_syntax_data("assets/json/syntax.txt", "assets/dependencies/test2.txt");
+        let _ = load_syntax_data("assets/json/syntax.txt", "assets/dependencies/test3.txt");
     }
 
     #[test]
     fn dependencies() {
-        let _data = load_syntax_data("assets/dependencies/syntax.txt",
-            "assets/dependencies/test.txt");
-        let _data = load_syntax_data("assets/dependencies/syntax.txt",
-            "assets/dependencies/test2.txt");
-        let _data = load_syntax_data("assets/dependencies/syntax.txt",
-            "assets/dependencies/test3.txt");
-        let _data = load_syntax_data("assets/dependencies/syntax.txt",
-            "assets/dependencies/test4.txt");
+        let _data = load_syntax_data(
+            "assets/dependencies/syntax.txt",
+            "assets/dependencies/test.txt",
+        );
+        let _data = load_syntax_data(
+            "assets/dependencies/syntax.txt",
+            "assets/dependencies/test2.txt",
+        );
+        let _data = load_syntax_data(
+            "assets/dependencies/syntax.txt",
+            "assets/dependencies/test3.txt",
+        );
+        let _data = load_syntax_data(
+            "assets/dependencies/syntax.txt",
+            "assets/dependencies/test4.txt",
+        );
         // json::print(&_data);
     }
 
     #[test]
     fn cargo_toml() {
-        let _data = load_syntax_data("assets/cargo-toml/syntax.txt",
-            "assets/cargo-toml/test.txt");
-        let _data = load_syntax_data("assets/cargo-toml/syntax.txt",
-            "assets/cargo-toml/test2.txt");
-        let _data = load_syntax_data("assets/cargo-toml/syntax.txt",
-            "assets/cargo-toml/test3.txt");
-        let _data = load_syntax_data("assets/cargo-toml/syntax.txt",
-            "assets/cargo-toml/test4.txt");
+        let _data = load_syntax_data("assets/cargo-toml/syntax.txt", "assets/cargo-toml/test.txt");
+        let _data = load_syntax_data(
+            "assets/cargo-toml/syntax.txt",
+            "assets/cargo-toml/test2.txt",
+        );
+        let _data = load_syntax_data(
+            "assets/cargo-toml/syntax.txt",
+            "assets/cargo-toml/test3.txt",
+        );
+        let _data = load_syntax_data(
+            "assets/cargo-toml/syntax.txt",
+            "assets/cargo-toml/test4.txt",
+        );
         // json::print(&_data);
     }
 
     #[test]
     fn update_is_json() {
-        let _ = load_syntax_data("assets/json/syntax.txt",
-            "assets/update/test.txt");
-        let _ = load_syntax_data("assets/json/syntax.txt",
-            "assets/update/test2.txt");
-        let _ = load_syntax_data("assets/json/syntax.txt",
-            "assets/update/test3.txt");
+        let _ = load_syntax_data("assets/json/syntax.txt", "assets/update/test.txt");
+        let _ = load_syntax_data("assets/json/syntax.txt", "assets/update/test2.txt");
+        let _ = load_syntax_data("assets/json/syntax.txt", "assets/update/test3.txt");
     }
 
     #[test]
     fn update() {
-        let _data = load_syntax_data("assets/update/syntax.txt",
-            "assets/update/test.txt");
-        let _data = load_syntax_data("assets/update/syntax.txt",
-            "assets/update/test2.txt");
-        let _data = load_syntax_data("assets/update/syntax.txt",
-            "assets/update/test3.txt");
+        let _data = load_syntax_data("assets/update/syntax.txt", "assets/update/test.txt");
+        let _data = load_syntax_data("assets/update/syntax.txt", "assets/update/test2.txt");
+        let _data = load_syntax_data("assets/update/syntax.txt", "assets/update/test3.txt");
         // json::print(&_data);
     }
 

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -14,15 +14,18 @@ pub fn todo_from_extract_info(extract_info: &str) -> Result<String, String> {
     use extract::*;
 
     let extract_meta_syntax = include_str!("../assets/extract/syntax.txt");
-    let extract_meta_rules = stderr_unwrap(extract_meta_syntax,
-        syntax(extract_meta_syntax));
+    let extract_meta_rules = stderr_unwrap(extract_meta_syntax, syntax(extract_meta_syntax));
     let mut extract_data = vec![];
-    stderr_unwrap(extract_info,
-        parse(&extract_meta_rules, extract_info, &mut extract_data));
+    stderr_unwrap(
+        extract_info,
+        parse(&extract_meta_rules, extract_info, &mut extract_data),
+    );
 
     let mut ignored = vec![];
-    let list = try!(convert_extract_info(&extract_data, &mut ignored)
-        .map_err(|_| String::from("Could not convert extract data")));
+    let list = try!(
+        convert_extract_info(&extract_data, &mut ignored)
+            .map_err(|_| String::from("Could not convert extract data"))
+    );
 
     let mut res: Vec<u8> = vec![];
     for package in &list {


### PR DESCRIPTION
I've run `cargo fmt` against the codebase, and added notes for contributors making PR's for eco on running rustfmt. Unfortunately, the latest version of rustfmt uses nightly, which will require the contributor to switch over to the nightly compiler to run `cargo fmt`. Hopefully this will be resolved soon to run on stable to avoid this problem.

Alternatively, we could use rustfmt on stable to minimise confusion until the new update is made available, but I'm worried that it's fairly out of date now.