### PR TITLE
Add TravisCI to eco

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: rust
+cache: cargo
+before_install:
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade openssl; fi
+matrix:
+  include:
+  - rust: nightly
+    script:
+    - cargo fmt -- --write-mode="diff"
+  - os: linux
+    dist: trusty
+  - os: osx
+    env:
+    - OPENSSL_INCLUDE_DIR="`brew --prefix openssl`/include"
+    - OPENSSL_LIB_DIR="`brew --prefix openssl`/lib"
+    - DEP_OPENSSL_INCLUDE="`brew --prefix openssl`/include"
+script:
+- cargo build
+- cargo test


### PR DESCRIPTION
Closes #160 

The tests covered by Travis are checking for rustfmt compliance in the codebase, and builds and tests running successfully in both Linux and macOS. I can add the badge to the README after the PR has been merged.