### PR TITLE
Fix rust_audio example

### DIFF
--- a/assets/extract/rust_audio.txt
+++ b/assets/extract/rust_audio.txt
@@ -41,7 +41,7 @@
   "envelope": {
     "url": "https://raw.githubusercontent.com/RustAudio/envelope/master/Cargo.toml"
   },
-  "rust-jack": {
+  "jack": {
     "url": "https://raw.githubusercontent.com/RustAudio/rust-jack/master/Cargo.toml"
   },
   "musical_keyboard": {


### PR DESCRIPTION
Closes #159 
I changed rust-jack to jack in the rust_audio asset file, the example stopped panicking.